### PR TITLE
Display number of likes for each item on the Homepage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
 import './style.css';
 import getMeals from './modules/getMeals.js';
 import popUp from './modules/PopUp.js';
+import getLikes from './modules/getLikes.js';
 
 const galleryContainer = document.querySelector('.gallery-container');
 let mealsArr = [];
 const showCards = async () => {
   try {
     mealsArr = await getMeals();
-    // const likeData = await getLikes();
+    const likeData = await getLikes();
     mealsArr.forEach((meal, id) => {
       const itemDiv = document.createElement('div');
       itemDiv.classList.add('gallery-item');
@@ -27,14 +28,14 @@ const showCards = async () => {
         </div>
       `;
 
-      //   const numOfLikeDiv = itemDiv.querySelector('.number-of-likes');
-      //   let mealLikes = 0;
-      //   const like = likeData.find((like) => like.item_id === id);
+      const numOfLikeDiv = itemDiv.querySelector('.number-of-likes');
+      let mealLikes = 0;
+      const like = likeData.find((like) => like.item_id === id);
 
-      //   if (like) {
-      //     mealLikes = like.likes;
-      //   }
-      //   numOfLikeDiv.textContent = `${mealLikes} Likes`;
+      if (like) {
+        mealLikes = like.likes;
+      }
+      numOfLikeDiv.textContent = `${mealLikes} Likes`;
       galleryContainer.appendChild(itemDiv);
       const commentBtns = itemDiv.querySelectorAll('.comment-btn');
       commentBtns.forEach((btn) => {

--- a/src/modules/getLikes.js
+++ b/src/modules/getLikes.js
@@ -1,0 +1,18 @@
+import { likeUrl } from './apiData.js';
+
+const getLikes = async () => {
+  try {
+    const response = await fetch(likeUrl, {
+      method: 'GET',
+      headers: {
+        'Content-type': 'application/json; charset=UTF-8',
+      },
+    });
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    return [];
+  }
+};
+
+export default getLikes;


### PR DESCRIPTION
When the page loads, the web app from the [Involvement API] shows the item likes and combines them with the data from the base API.

The page makes only 2 requests:
- one to the base API
- and **one** to the Involvement API.

This task **does not** include displaying the likes button (heart icon on the wireframe) for each item.